### PR TITLE
Upvote Credits

### DIFF
--- a/supabase/migrations/202601290100_update_vote_credit_trigger.sql
+++ b/supabase/migrations/202601290100_update_vote_credit_trigger.sql
@@ -48,3 +48,40 @@ begin
   return new;
 end;
 $$;
+
+-- Replace vote policies to require purchase/download before voting.
+drop policy if exists "Users upsert own vote" on public.votes;
+drop policy if exists "Users update own vote" on public.votes;
+
+create policy "Users upsert own vote" on public.votes
+for insert
+with check (
+  auth.uid() = profile_id
+  and exists (
+    select 1
+    from public.resource_downloads d
+    where d.resource_id = votes.resource_id
+      and d.profile_id = auth.uid()
+  )
+);
+
+create policy "Users update own vote" on public.votes
+for update
+using (
+  auth.uid() = profile_id
+  and exists (
+    select 1
+    from public.resource_downloads d
+    where d.resource_id = votes.resource_id
+      and d.profile_id = auth.uid()
+  )
+)
+with check (
+  auth.uid() = profile_id
+  and exists (
+    select 1
+    from public.resource_downloads d
+    where d.resource_id = votes.resource_id
+      and d.profile_id = auth.uid()
+  )
+);


### PR DESCRIPTION
## Linked Issues
Closes #<12>

## Summary
(Updated using SQL editor in DB)
- 3 credits per upvote (updates: credit_ledger & profiles.credits)
- Caps at a max of 10 credits

(To be updated using SQL editor in DB)
- Only allows people who "purchased" resource to vote 

Code in: migrations/202601290100_update_vote_credit_trigger.sql

## How to Test
- Use SQL editor to insert a new vote on a resource

## Checklist
- [x] Tests added/updated
- [x] Lint/tests pass locally
- [x] Docs updated (README/ADR/changelog)
