### PR TITLE
feat: add resource type to uploads

### DIFF
--- a/frontend/app/api/upload/route.ts
+++ b/frontend/app/api/upload/route.ts
@@ -5,6 +5,12 @@ import { createClient } from "@supabase/supabase-js";
 const MAX_FILE_SIZE_BYTES = 25 * 1024 * 1024;
 const PDF_MIME_TYPES = new Set(["application/pdf"]);
 const STORAGE_BUCKET = "resources";
+const RESOURCE_TYPES = new Set([
+  "lecture_notes",
+  "study_guide",
+  "class_overview",
+  "link",
+]);
 
 const isUuid = (value: string) =>
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value);
@@ -82,6 +88,7 @@ export async function POST(req: NextRequest) {
   const file = formData.get("file");
   const classId = (formData.get("class_id") as string | null)?.trim();
   const title = (formData.get("title") as string | null)?.trim();
+  const resourceType = (formData.get("resource_type") as string | null)?.trim();
 
   if (!(file instanceof File)) {
     return NextResponse.json({ error: "A PDF file is required." }, { status: 400 });
@@ -94,6 +101,13 @@ export async function POST(req: NextRequest) {
   if (!title || title.length > 200) {
     return NextResponse.json(
       { error: "title is required and must be at most 200 characters." },
+      { status: 400 },
+    );
+  }
+
+  if (!resourceType || !RESOURCE_TYPES.has(resourceType)) {
+    return NextResponse.json(
+      { error: "resource_type must be a valid value." },
       { status: 400 },
     );
   }
@@ -156,6 +170,7 @@ export async function POST(req: NextRequest) {
       profile_id: userId,
       course_id: classId,
       title,
+      resource_type: resourceType,
       file_key: filePath,
       preview_key: filePath,
     })

--- a/frontend/app/upload/page.tsx
+++ b/frontend/app/upload/page.tsx
@@ -38,6 +38,13 @@ const emptyCourseRequest: CourseRequestForm = {
   justification: "",
 };
 
+const resourceTypeOptions = [
+  { label: "Lecture Notes", value: "lecture_notes" },
+  { label: "Study Guide", value: "study_guide" },
+  { label: "Class Overview", value: "class_overview" },
+  { label: "Link", value: "link" },
+] as const;
+
 export default function UploadPage() {
   const [classes, setClasses] = useState<ClassOption[]>([]);
   const [classSearch, setClassSearch] = useState("");
@@ -56,6 +63,7 @@ export default function UploadPage() {
   const [numPages, setNumPages] = useState<number | null>(null);
   const [pageNumber, setPageNumber] = useState(1);
   const [title, setTitle] = useState("");
+  const [resourceType, setResourceType] = useState("");
   const [accessToken, setAccessToken] = useState<string | null>(null);
   const [result, setResult] = useState<string | null>(null);
   const [submitError, setSubmitError] = useState<string | null>(null);
@@ -288,6 +296,12 @@ export default function UploadPage() {
       return;
     }
 
+    if (!resourceType) {
+      setSubmitError("Please select a resource type.");
+      setIsUploading(false);
+      return;
+    }
+
     if (!accessToken) {
       setSubmitError("Missing access token. Please re-authenticate.");
       setIsUploading(false);
@@ -298,6 +312,7 @@ export default function UploadPage() {
     formData.append("file", file);
     formData.append("class_id", classId);
     formData.append("title", title);
+    formData.append("resource_type", resourceType);
 
     try {
       const res = await fetch("/api/upload", {
@@ -533,6 +548,28 @@ export default function UploadPage() {
               onChange={(e) => setTitle(e.target.value)}
               placeholder="Example: Midterm review sheet"
             />
+          </div>
+
+          <div className="upload-field">
+            <label className="upload-label" htmlFor="resource-type">
+              Resource type
+            </label>
+            <select
+              id="resource-type"
+              className="upload-input"
+              value={resourceType}
+              onChange={(e) => setResourceType(e.target.value)}
+              required
+            >
+              <option value="" disabled>
+                Select a type
+              </option>
+              {resourceTypeOptions.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
           </div>
 
         {/* remove in production, kept for testing purposes */}

--- a/supabase/migrations/202503090000_add_resource_type_to_resources.sql
+++ b/supabase/migrations/202503090000_add_resource_type_to_resources.sql
@@ -1,0 +1,15 @@
+alter table public.resources
+  add column if not exists resource_type text;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'check_resource_type'
+  ) then
+    alter table public.resources
+      add constraint check_resource_type
+      check (resource_type in ('lecture_notes', 'study_guide', 'class_overview', 'link'));
+  end if;
+end $$;


### PR DESCRIPTION
## Linked Issues
Closes #31 

## Summary
Add a required resource type selector to the upload form and send it to the upload API, which now validates and stores resource_type on the resource record. Includes a migration to add the resource_type column + constraint.

## How to Test
1. npm run dev
2. Open /upload, select a class, pick each resource type, upload a PDF
3. Confirm the upload succeeds and the resource’s resource_type is saved in the DB


## Screenshots / Demos
<img width="1627" height="479" alt="image" src="https://github.com/user-attachments/assets/8cc39752-d98f-4005-b6a2-32925a0bbb69" />

<img width="1782" height="594" alt="image" src="https://github.com/user-attachments/assets/fe1aedcd-8428-47d0-82e6-7f73c4062406" />

